### PR TITLE
Register Atmospheric config values with config condition

### DIFF
--- a/src/main/java/com/minecraftabnormals/atmospheric/core/Atmospheric.java
+++ b/src/main/java/com/minecraftabnormals/atmospheric/core/Atmospheric.java
@@ -1,5 +1,6 @@
 package com.minecraftabnormals.atmospheric.core;
 
+import com.minecraftabnormals.abnormals_core.core.util.DataUtil;
 import com.minecraftabnormals.abnormals_core.core.util.registry.RegistryHelper;
 import com.minecraftabnormals.atmospheric.core.other.AtmosphericCompat;
 import com.minecraftabnormals.atmospheric.core.other.AtmosphericRender;
@@ -41,6 +42,7 @@ public class Atmospheric {
 
 		ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, AtmosphericConfig.COMMON_SPEC);
 		ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, AtmosphericConfig.CLIENT_SPEC);
+		DataUtil.registerConfigCondition(Atmospheric.MOD_ID, AtmosphericConfig.COMMON, AtmosphericConfig.CLIENT);
 	}
 
 	private void setup(final FMLCommonSetupEvent event) {

--- a/src/main/java/com/minecraftabnormals/atmospheric/core/AtmosphericConfig.java
+++ b/src/main/java/com/minecraftabnormals/atmospheric/core/AtmosphericConfig.java
@@ -1,5 +1,6 @@
 package com.minecraftabnormals.atmospheric.core;
 
+import com.minecraftabnormals.abnormals_core.core.annotations.ConfigKey;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
 import org.apache.commons.lang3.tuple.Pair;
@@ -7,20 +8,46 @@ import org.apache.commons.lang3.tuple.Pair;
 public class AtmosphericConfig {
 
 	public static class Common {
+
+		@ConfigKey("rainforest_weight")
 		public final ConfigValue<Integer> rainforestWeight;
+
+		@ConfigKey("rainforest_mountains_weight")
 		public final ConfigValue<Integer> rainforestMountainsWeight;
+
+		@ConfigKey("rainforest_plateau_weight")
 		public final ConfigValue<Integer> rainforestPlateauWeight;
+
+		@ConfigKey("sparse_rainforest_plateau_weight")
 		public final ConfigValue<Integer> sparseRainforestPlateauWeight;
+
+		@ConfigKey("rainforest_basin_weight")
 		public final ConfigValue<Integer> rainforestBasinWeight;
+
+		@ConfigKey("sparse_rainforest_basin_weight")
 		public final ConfigValue<Integer> sparseRainforestBasinWeight;
 
+
+		@ConfigKey("dunes_weight")
 		public final ConfigValue<Integer> dunesWeight;
+
+		@ConfigKey("dunes_hills_weight")
 		public final ConfigValue<Integer> dunesHillsWeight;
+
+		@ConfigKey("flourishing_dunes_weight")
 		public final ConfigValue<Integer> flourishingDunesWeight;
+
+		@ConfigKey("rocky_dunes_weight")
 		public final ConfigValue<Integer> rockyDunesWeight;
+
+		@ConfigKey("rocky_dunes_hills_weight")
 		public final ConfigValue<Integer> rockyDunesHillsWeight;
+
+		@ConfigKey("petrified_dunes_weight")
 		public final ConfigValue<Integer> petrifiedDunesWeight;
 
+
+		@ConfigKey("hot_springs_weight")
 		public final ConfigValue<Integer> hotSpringsWeight;
 
 		Common(ForgeConfigSpec.Builder builder) {
@@ -55,6 +82,8 @@ public class AtmosphericConfig {
 	}
 
 	public static class Client {
+
+		@ConfigKey("show_unobtainable_description")
 		public final ConfigValue<Boolean> showUnobtainableDescription;
 
 		public Client(ForgeConfigSpec.Builder builder) {


### PR DESCRIPTION
This is a PR I've been meaning to do for ages, but I haven't got around to until now. A while ago a config condition system was added to Abnormals Core which lets recipes, advancement/loot modifiers, loot tables and whatever else use the value of a config entry as a json condition, like this:
```
"conditions": [
  {
    "type": "abnormals_core:config",
    "value": "potato_poison_chance",
    "predicates": [
      {
        "type": "abnormals_core:greater_than_or_equal_to",
        "value": 0.1,
        "inverted": true
      }
    ]
  }
],
//Loot pool/modifier/etc. here
```
To support this, mods need to register their config objects in the `DataUtil#registerConfigCondition` method and annotate all the `ConfigValue` fields with `@ConfigKey` which specifies the string key for that value in json. I've done that for this PR, and I'll change the specific strings used for the config values if anyone requests.